### PR TITLE
Enable OPcache and JIT when running PHP

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -504,7 +504,15 @@ fn run_php(context: &RunContext) -> Result<ExecResult> {
     for i in 0..context.times {
         let start_time = Instant::now();
         let mut child = Command::new("php")
-            .args(vec!["sol.php"])
+            .args(vec![
+                "-d", "opcache.memory_consumption=128",
+                "-d", "opcache.interned_strings_buffer=8",
+                "-d", "opcache.revalidate_freq=60",
+                "-d", "opcache.enable_cli=1",
+                "-d", "opcache.jit=function",
+                "-d", "opcache.jit_buffer_size=128M",
+                "-f", "sol.php"
+            ])
             .current_dir(&tmp_dir)
             .spawn()?;
 


### PR DESCRIPTION
Hello,

The goal of this PR is to enable OPcache and JIT compiler flags when running PHP. This is similar to the `-O` and `-O3` flags that are used when compiling Rust and C++.

The exact flags and values to use can be discussed, I chose these values based on the recommendations from the official documentation: https://www.php.net/manual/en/opcache.installation.php

Adding these flags made my execution time go from `3.78 sec` to `2.25 sec` in some of my tests which is not negligible.

These options can be changed globally in the `php.ini` or provided to the `php` command like I did in this PR.

Let me know what you think about this change.