### PR TITLE
Possible improvements of the runner

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -286,50 +286,50 @@ fn run_rust(context: &RunContext) -> Result<ExecResult> {
     })
 }
 fn run_cpp(context: &RunContext) -> Result<ExecResult> {
-    let tmp_dir = tempfile::tempdir()?;
-
-    let mut output_path = tmp_dir.path().to_path_buf();
-    output_path.push("sol");
-
-    let mut res = Command::new("/usr/bin/g++")
-        .args(vec![
-            "-Wall",
-            "--std=c++17",
-            "-O3",
-            context.abs_solution().to_str().unwrap(),
-            "-o",
-            output_path.to_str().unwrap(),
-        ])
-        .spawn()?;
-
-    match res.wait() {
-        Ok(status) => {
-            info!("Finished compilation of the target: {output_path:?} with exit code: {status}");
-            if let Some(code) = status.code() {
-                if code != 0 {
-                    return Err(anyhow::anyhow!(
-                        "Failed to compile solution file: none-zero exit code"
-                    ));
-                }
-            }
-        }
-        Err(e) => return Err(anyhow::anyhow!("Failed to compile solution file: {e:?}")),
-    }
-
-    let mut input_file = tmp_dir.path().to_path_buf();
-    input_file.push("input.txt");
-    let mut output_file = tmp_dir.path().to_path_buf();
-    output_file.push("output.txt");
-
-    info!(
-        "Symlinking file from: {:?} to {:?}",
-        context.input_file, input_file
-    );
-
-    std::os::unix::fs::symlink(context.input_file, &input_file)?;
-
     let mut times = vec![];
     for i in 0..context.times {
+        let tmp_dir = tempfile::tempdir()?;
+
+        let mut output_path = tmp_dir.path().to_path_buf();
+        output_path.push("sol");
+
+        let mut res = Command::new("/usr/bin/g++")
+            .args(vec![
+                "-Wall",
+                "--std=c++17",
+                "-O3",
+                context.abs_solution().to_str().unwrap(),
+                "-o",
+                output_path.to_str().unwrap(),
+            ])
+            .spawn()?;
+
+        match res.wait() {
+            Ok(status) => {
+                info!("Finished compilation of the target: {output_path:?} with exit code: {status}");
+                if let Some(code) = status.code() {
+                    if code != 0 {
+                        return Err(anyhow::anyhow!(
+                            "Failed to compile solution file: none-zero exit code"
+                        ));
+                    }
+                }
+            }
+            Err(e) => return Err(anyhow::anyhow!("Failed to compile solution file: {e:?}")),
+        }
+
+        let mut input_file = tmp_dir.path().to_path_buf();
+        input_file.push("input.txt");
+        let mut output_file = tmp_dir.path().to_path_buf();
+        output_file.push("output.txt");
+
+        info!(
+            "Symlinking file from: {:?} to {:?}",
+            context.input_file, input_file
+        );
+
+        std::os::unix::fs::symlink(context.input_file, &input_file)?;
+
         cooloff(context)?;
         debug!("Starting execution #{i}");
         let start_time = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,20 +42,22 @@ struct Args {
     #[arg(long, default_value_t = 5)]
     times_to_run: u32,
 
-    #[arg(long)]
+    #[arg(long, default_value_t = String::new())]
     cgroup_path: String,
 }
 
 // Move the pid to the cgroup
 fn move_to_cgroup(pid: u32, context: &RunContext) -> Result<()> {
-    let procs_file_path = format!("{}/cgroup.procs", context.cgroup_path);
-    let pid_string = pid.to_string();
+    if !context.cgroup_path.is_empty() {
+        let procs_file_path = format!("{}/cgroup.procs", context.cgroup_path);
+        let pid_string = pid.to_string();
 
-    std::fs::OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open(procs_file_path)?
-        .write_all(pid_string.as_bytes())?;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(procs_file_path)?
+            .write_all(pid_string.as_bytes())?;
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -901,6 +901,7 @@ fn run_file(context: &RunContext) -> Result<ExecResult> {
     source_file.push(context.solution_file);
     match extension.to_str().unwrap() {
         "cpp" => run_cpp(context),
+        "cxx" => run_cpp(context),
         "cc" => run_cpp(context),
         "c" => run_cpp(context),
         "java" => run_java(context),


### PR DESCRIPTION
In response to @chermehdi 's request here https://github.com/geeksblabla/blanat/discussions/224#discussioncomment-8620840

commit 0998594d8a75d5f9ff6ff11f3b8138756518eb56
Author: sehe <sgheeren@gmail.com>
Date:   Fri Mar 1 02:10:51 2024 +0100

    Make cgroup_path optional
    
    Because it doesn't work well in my docker environment. There seems to be a
    race condition that causes e.g. java to loose the current working
    directory because the move_to_cgroup happens late

commit d7dc7286452008148220b9fd1a520de55c13898e
Author: sehe <sgheeren@gmail.com>
Date:   Fri Mar 1 02:12:50 2024 +0100

    Add optional cooloff_sec option
    
    Allows for system to cool down to CPU scaling/temp throttling doesn't
    ruin the results as much.
    
    Of course the only *real* way is to run this on dedicated bare metal and
    disable CPU scaling altogether

commit a1d9e1680387d4732b9209a606c5e62b7a72e854
Author: sehe <sgheeren@gmail.com>
Date:   Fri Mar 1 02:34:05 2024 +0100

    Also drop_caches on cooloff

commit db75102b116ac39dc975bf77bb899196e6f28ce9
Author: sehe <sgheeren@gmail.com>
Date:   Fri Mar 1 02:34:47 2024 +0100

    recognize cxx extension as c++

commit 52eda2b906adfd749eec6a600b58a5acc85cbba3 (HEAD -> main, origin/main, origin/HEAD)
Author: sehe <sgheeren@gmail.com>
Date:   Fri Mar 1 03:17:11 2024 +0100

    Tentative workaround against local cache cheating
    
    Better would be to build in staging dir and repeated copy to staging,
    but I have no time to learn enough rust to do it in 10 minutes