### PR TITLE
Add changes for the final run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn compute_verdict(output: &Path, expected_output: &Path) -> Result<Verdict> {
     output.read_to_string(&mut output_str)?;
     expected_output.read_to_string(&mut ex_output_str)?;
     if output_str.trim() != ex_output_str.trim() {
-        info!("Solution comparison failed, output for the solution is: {output_str}");
+        info!("Solution comparison failed, output for the solution is: {output_str}\n expected output is {ex_output_str}");
         return Ok(Verdict::Wa);
     }
     Ok(Verdict::Ac)

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,6 +394,7 @@ fn ensure_correct(
         );
         std::fs::copy(context.abs_solution(), &sol_file)?;
         if context.lang()? == "java" {
+            debug!("Recompiling Java solution for correctness checks");
             // Java could generate more than one file after compilation, let's recompile to ensure
             // that '.class' files are getting properly generated.
             let mut res = Command::new("javac")
@@ -655,7 +656,11 @@ fn run_java(context: &RunContext) -> Result<ExecResult> {
         Err(e) => return Err(anyhow::anyhow!("Failed to compile solution file: {e:?}")),
     }
 
-    let verdict = ensure_correct(context, vec!["java".to_string(), "Main".to_string()], None)?;
+    let verdict = ensure_correct(
+        context,
+        vec!["java".to_string(), "Main".to_string()],
+        Some("Main.java"),
+    )?;
     if !matches!(verdict, Verdict::Ac) {
         info!("Solution failed correctness checks, exiting early");
         return Ok(ExecResult {

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,7 +196,7 @@ fn run_rust(context: &RunContext) -> Result<ExecResult> {
     let mut output_path = tmp_dir.path().to_path_buf();
     output_path.push("sol");
 
-    let mut res = Command::new("/usr/local/bin/rustc")
+    let mut res = Command::new("rustc")
         .args(vec![
             "-O",
             context.abs_solution().to_str().unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,7 @@ fn extract_files(directory_path: &Path, suf: &str) -> Vec<PathBuf> {
         }
     }
 
+    in_files.sort();
     in_files
 }
 
@@ -414,6 +415,10 @@ fn ensure_correct(context: &RunContext, cmd: Vec<String>) -> Result<Verdict> {
         debug!("Correctness execution finished in: {elapsed:?}");
 
         if let Some(expected_output) = get_matching_output(&file_path, &out_files) {
+            debug!(
+                "Found matching output_file: input: {:?}, output: {:?}",
+                file_path, expected_output
+            );
             let verdict = compute_verdict(&output_path, &expected_output)?;
             if !matches!(verdict, Verdict::Ac) {
                 info!("Solution didn't pass correctness check, aborting early!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,7 +334,11 @@ fn extract_files(directory_path: &Path, suf: &str) -> Vec<PathBuf> {
 
 fn copy_to_input_txt(input_path: &Path, file_path: &Path) -> Result<()> {
     // Create or open the input.txt file for writing
-    let mut input_txt_file = std::fs::File::create(input_path)?;
+    let mut input_txt_file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(input_path)?;
 
     // Open the input file for reading
     let mut file = std::fs::File::open(file_path)?;
@@ -343,8 +347,7 @@ fn copy_to_input_txt(input_path: &Path, file_path: &Path) -> Result<()> {
     let mut content = String::new();
     file.read_to_string(&mut content)?;
 
-    // Write the content to the input.txt file
-    writeln!(&mut input_txt_file, "{}", content)?;
+    input_txt_file.write_all(content.as_bytes())?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,13 +122,20 @@ struct ExecResult {
 
 impl ExecResult {
     pub fn avg_time(&self) -> Duration {
-        if self.times.is_empty() {
+        let mut times = self.times.clone();
+        times.sort();
+        if times.is_empty() {
             return Duration::from_millis(0);
         }
-        // Remove the slowest and fastest solutions to further remove outliers
-        let new_times = &self.times[1..self.times.len() - 1];
-        let sum: Duration = new_times.iter().sum();
-        sum / (self.times.len() as u32)
+        if times.len() > 2 {
+            // Remove the slowest and fastest solutions to further remove outliers
+            let new_times = &times[1..self.times.len() - 1];
+            let sum: Duration = new_times.iter().sum();
+            sum / (new_times.len() as u32)
+        } else {
+            let sum: Duration = times.iter().sum();
+            sum / (self.times.len() as u32)
+        }
     }
 
     pub fn median(&self) -> Duration {
@@ -137,9 +144,13 @@ impl ExecResult {
         }
         let mut times = self.times.clone();
         times.sort();
-        // Remove the slowest and fastest solutions to further remove outliers
-        let new_times = &times[1..times.len() - 1];
-        new_times[new_times.len() / 2]
+        if times.len() > 2 {
+            // Remove the slowest and fastest solutions to further remove outliers
+            let new_times = &times[1..times.len() - 1];
+            new_times[new_times.len() / 2]
+        } else {
+            times[times.len() / 2]
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1093,7 +1093,7 @@ fn run_golang(context: &RunContext) -> Result<ExecResult> {
     let mut output_path = tmp_dir.path().to_path_buf();
     output_path.push("sol");
 
-    let mut res = Command::new("/usr/local/bin/go")
+    let mut res = Command::new("go")
         .args(vec![
             "build",
             "-o",
@@ -1115,6 +1115,23 @@ fn run_golang(context: &RunContext) -> Result<ExecResult> {
         }
         Err(e) => return Err(anyhow::anyhow!("Failed to compile solution file: {e:?}")),
     }
+
+    let verdict = ensure_correct(
+        context,
+        vec![output_path.to_str().unwrap().to_string()],
+        None,
+    )?;
+    if !matches!(verdict, Verdict::Ac) {
+        info!("Solution failed correctness checks, exiting early");
+        return Ok(ExecResult {
+            verdict,
+            times: vec![],
+        });
+    }
+
+    info!("Solution passed correctness checks");
+
+    drop_file_cache()?;
 
     let mut input_file = tmp_dir.path().to_path_buf();
     input_file.push("input.txt");


### PR DESCRIPTION
The change is based on feedback from discussion on Github mainly around filesystem cache bia in-between runs and ensuring correctness.

* We now should run solutions against a bunch of input/output pairs of 1M rows each and verify that they produce the correct input and exit early if there is a failure.
* We drop the Linux filesystem cache after syncing any dirty pages to Disk before each run.
* The runner will now run for 10 times (5 more times) to ensure minimal variance, and also we will drop the two most outliers when counting the results (slowest and fastest solutions).